### PR TITLE
Add new converter type whose rates are multiplied by a resource amount

### DIFF
--- a/src/BackgroundResourceProcessing/BackgroundResourceProcessor.Internals.cs
+++ b/src/BackgroundResourceProcessing/BackgroundResourceProcessor.Internals.cs
@@ -121,8 +121,11 @@ public sealed partial class BackgroundResourceProcessor
         if (ShadowState.Value.NextTerminatorEstimate <= changepoint)
             ShadowState = Shadow.GetShadowState(vessel);
 
-        var state = new VesselState(changepoint);
-        state.SetShadowState(ShadowState.Value);
+        var state = new VesselState(changepoint)
+        {
+            Processor = this,
+            ShadowState = (Shadow)ShadowState,
+        };
 
         var recompute = false;
         ImmediateChangepointRequested = false;
@@ -170,8 +173,11 @@ public sealed partial class BackgroundResourceProcessor
         );
 
         ShadowState = Shadow.GetShadowState(vessel);
-        var state = new VesselState(Planetarium.GetUniversalTime());
-        state.SetShadowState(ShadowState.Value);
+        var state = new VesselState(Planetarium.GetUniversalTime())
+        {
+            Processor = this,
+            ShadowState = (Shadow)ShadowState,
+        };
 
         processor.UpdateState(state.CurrentTime, true);
         processor.UpdateConstraintState();
@@ -240,7 +246,7 @@ public sealed partial class BackgroundResourceProcessor
             processor.ClearVesselState();
 
         var currentTime = Planetarium.GetUniversalTime();
-        var state = new VesselState(currentTime);
+        var state = new VesselState(currentTime) { Processor = this };
 
         // If we have already been saved this frame then there is nothing else
         // we need to do here.
@@ -248,7 +254,7 @@ public sealed partial class BackgroundResourceProcessor
             return;
 
         ShadowState = Shadow.GetShadowState(vessel);
-        state.SetShadowState((Shadow)ShadowState);
+        state.ShadowState = (Shadow)ShadowState;
 
         processor.RecordVesselState(vessel, currentTime);
         processor.RecordProtoInventories(vessel);

--- a/src/BackgroundResourceProcessing/BackgroundResourceProcessor.Internals.cs
+++ b/src/BackgroundResourceProcessing/BackgroundResourceProcessor.Internals.cs
@@ -256,7 +256,7 @@ public sealed partial class BackgroundResourceProcessor
         ShadowState = Shadow.GetShadowState(vessel);
         state.ShadowState = (Shadow)ShadowState;
 
-        processor.RecordVesselState(vessel, currentTime);
+        processor.RecordVesselState(vessel, state);
         processor.RecordProtoInventories(vessel);
         using (var eventspan = new TraceSpan("onVesselRecord"))
             onVesselRecord.Fire(this);

--- a/src/BackgroundResourceProcessing/Behaviour/ResourceRelativeBehaviour.cs
+++ b/src/BackgroundResourceProcessing/Behaviour/ResourceRelativeBehaviour.cs
@@ -1,0 +1,228 @@
+using System.Collections.Generic;
+using BackgroundResourceProcessing.Collections;
+
+namespace BackgroundResourceProcessing.Behaviour;
+
+/// <summary>
+/// A behaviour which has rates that are scaled relative to the amount of
+/// a resource present in inventories on this vessel.
+/// </summary>
+public class ResourceRelativeBehaviour : ConverterBehaviour
+{
+    public struct ScaledRatio() : ConfigUtil.IConfigLoadable
+    {
+        public ResourceRatio ResourceRatio;
+
+        /// <summary>
+        /// Whether this resource rate should not be multiplied by the
+        /// resource amount.
+        /// </summary>
+        public bool Fixed = false;
+
+        public string ResourceName
+        {
+            readonly get => ResourceRatio.ResourceName;
+            set => ResourceRatio.ResourceName = value;
+        }
+
+        public double Ratio
+        {
+            readonly get => ResourceRatio.Ratio;
+            set => ResourceRatio.Ratio = value;
+        }
+
+        public bool DumpExcess
+        {
+            readonly get => ResourceRatio.DumpExcess;
+            set => ResourceRatio.DumpExcess = value;
+        }
+
+        public ResourceFlowMode FlowMode
+        {
+            readonly get => ResourceRatio.FlowMode;
+            set => ResourceRatio.FlowMode = value;
+        }
+
+        public void Load(ConfigNode node)
+        {
+            ResourceRatio.Load(node);
+            node.TryGetValue(nameof(Fixed), ref Fixed);
+        }
+
+        public void Save(ConfigNode node)
+        {
+            ResourceRatio.Save(node);
+            node.AddValue(nameof(Fixed), Fixed);
+        }
+    }
+
+    public List<ScaledRatio> Inputs;
+    public List<ScaledRatio> Outputs;
+    public List<ResourceConstraint> Required;
+
+    /// <summary>
+    /// The name of the resource whose amount will be used to multiply the
+    /// input and output rates of this converter.
+    /// </summary>
+    [KSPField(isPersistant = true)]
+    public string ResourceName;
+
+    /// <summary>
+    /// The maximum relative error that this behaviour will allow before
+    /// creating a changepoint.
+    /// </summary>
+    [KSPField(isPersistant = true)]
+    public double MaxError = 0.1;
+
+    /// <summary>
+    /// The minimum amount of time between consecutive changepoints for this
+    /// converter, in seconds.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// This is to prevent infinite changepoints if the resource this behaviour
+    /// depends on is decreasing due to other converters.
+    /// </remarks>
+    [KSPField(isPersistant = true)]
+    public double MinChangepointDelta = 600.0;
+
+    /// <summary>
+    /// The amount value the last time <see cref="GetResources"/> was called.
+    /// </summary>
+    [KSPField(isPersistant = true)]
+    private double LastAmount = 0.0;
+
+    [KSPField(isPersistant = true)]
+    private double LastChangepoint = 0.0;
+
+    /// <summary>
+    /// The set of inventories that are taken into account when determining the
+    /// amount of available resource.
+    /// </summary>
+    public DynamicBitSet Connected;
+
+    public override ConverterResources GetResources(VesselState state)
+    {
+        var inventories = state.Processor.Inventories;
+        var resourceId = ResourceName.GetHashCode();
+        double amount = 0.0;
+        foreach (var invId in Connected)
+        {
+            if (invId >= inventories.Count)
+                continue;
+
+            var inventory = inventories[invId];
+            if (inventory.ResourceId != resourceId)
+                continue;
+
+            amount += inventory.Amount;
+        }
+
+        LastAmount = amount;
+        LastChangepoint = state.CurrentTime;
+        return new ConverterResources()
+        {
+            Inputs = MultiplyRatios(Inputs, amount),
+            Outputs = MultiplyRatios(Outputs, amount),
+            Requirements = Required,
+        };
+    }
+
+    public override void OnRatesComputed(
+        BackgroundResourceProcessor processor,
+        Core.ResourceConverter converter,
+        RateCalculatedEvent evt
+    )
+    {
+        var inventories = processor.Inventories;
+        var resourceId = ResourceName.GetHashCode();
+        double amount = 0.0;
+        double rate = 0.0;
+        foreach (var invId in Connected)
+        {
+            if (invId >= inventories.Count)
+                continue;
+
+            var inventory = inventories[invId];
+            if (inventory.ResourceId != resourceId)
+                continue;
+
+            amount += inventory.Amount;
+            rate += inventory.Rate;
+        }
+
+        if (rate == 0.0)
+        {
+            converter.NextChangepoint = double.PositiveInfinity;
+            return;
+        }
+
+        double hi = LastAmount * (1 + MaxError);
+        double lo = LastAmount * (1 - MaxError);
+
+        // Someone manually updated the resources within the inventories we
+        // care about. We unfortunately need to perform another changepoint
+        // immediately.
+        if (amount <= lo || hi <= amount)
+        {
+            converter.NextChangepoint = evt.CurrentTime;
+            processor.SuppressNoProgressError();
+            return;
+        }
+
+        double bound = rate < 0.0 ? lo : hi;
+        double dt = (bound - amount) / rate * MaxError;
+        if (dt < 1.0)
+            dt = 1.0;
+
+        double next = evt.CurrentTime + dt;
+        if (next < LastChangepoint + MinChangepointDelta)
+            next = LastChangepoint + MinChangepointDelta;
+
+        converter.NextChangepoint = next;
+    }
+
+    protected override void OnLoad(ConfigNode node)
+    {
+        base.OnLoad(node);
+
+        Inputs = ConfigUtil.LoadNodeList<ScaledRatio>(node, "INPUT_RESOURCE");
+        Outputs = ConfigUtil.LoadNodeList<ScaledRatio>(node, "OUTPUT_RESOURCE");
+        Required = ConfigUtil.LoadNodeList<ResourceConstraint>(node, "REQUIRED_RESOURCE");
+
+        Connected = new(8);
+
+        var values = node.GetValues(nameof(Connected));
+        for (int i = values.Length - 1; i >= 0; ++i)
+        {
+            if (uint.TryParse(values[i], out var index))
+                Connected.Add(index);
+        }
+    }
+
+    protected override void OnSave(ConfigNode node)
+    {
+        base.OnSave(node);
+
+        ConfigUtil.SaveNodeList(node, "INPUT_RESOURCE", Inputs);
+        ConfigUtil.SaveNodeList(node, "OUTPUT_RESOURCE", Outputs);
+        ConfigUtil.SaveNodeList(node, "REQUIRED_RESOURCE", Required);
+
+        foreach (var index in Connected)
+            node.AddValue(nameof(Connected), index);
+    }
+
+    private static List<ResourceRatio> MultiplyRatios(List<ScaledRatio> ratios, double amount)
+    {
+        List<ResourceRatio> results = new(ratios.Count);
+        foreach (var _ratio in ratios)
+        {
+            var ratio = _ratio;
+            if (!ratio.Fixed)
+                ratio.Ratio *= amount;
+            results.Add(ratio.ResourceRatio);
+        }
+
+        return results;
+    }
+}

--- a/src/BackgroundResourceProcessing/Collections/DynamicBitSet.cs
+++ b/src/BackgroundResourceProcessing/Collections/DynamicBitSet.cs
@@ -122,6 +122,8 @@ public class DynamicBitSet : IEnumerable<int>
             words[i] |= bitset.words[i];
     }
 
+    public void Clear() => Array.Clear(words, 0, words.Length);
+
     private void Expand(int required)
     {
         var newCap = Math.Max(words.Length * 2, required);

--- a/src/BackgroundResourceProcessing/Converter/BackgroundConstantConverter.cs
+++ b/src/BackgroundResourceProcessing/Converter/BackgroundConstantConverter.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using BackgroundResourceProcessing.Behaviour;
 using BackgroundResourceProcessing.Collections;
 using BackgroundResourceProcessing.Utils;
-using UnityEngine.Playables;
 
 namespace BackgroundResourceProcessing.Converter;
 
@@ -14,8 +13,6 @@ namespace BackgroundResourceProcessing.Converter;
 /// </summary>
 public class BackgroundConstantConverter : BackgroundConverter
 {
-    const BindingFlags Flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
-
     public List<ResourceRatioExpression> inputs = [];
     public List<ResourceRatioExpression> outputs = [];
     public List<ResourceConstraintExpression> required = [];
@@ -46,14 +43,17 @@ public class BackgroundConstantConverter : BackgroundConverter
         if (!ActiveCondition.Evaluate(module))
             return null;
 
-        IEnumerable<ResourceRatio> inputs = this.inputs.TrySelect<ResourceRatioExpression, ResourceRatio>(
-            (input, out value) => input.Evaluate(module, out value)
+        var inputs = this.inputs.TrySelect(
+            (ResourceRatioExpression input, out ResourceRatio value) =>
+                input.Evaluate(module, out value)
         );
-        IEnumerable<ResourceRatio> outputs = this.outputs.TrySelect<ResourceRatioExpression, ResourceRatio>(
-            (output, out value) => output.Evaluate(module, out value)
+        var outputs = this.outputs.TrySelect(
+            (ResourceRatioExpression output, out ResourceRatio value) =>
+                output.Evaluate(module, out value)
         );
-        IEnumerable<ResourceConstraint> required = this.required.TrySelect<ResourceConstraintExpression, ResourceConstraint>(
-            (req, out value) => req.Evaluate(module, out value)
+        var required = this.required.TrySelect(
+            (ResourceConstraintExpression req, out ResourceConstraint value) =>
+                req.Evaluate(module, out value)
         );
 
         inputs = inputs.Concat(GetResourceList(module, InputList) ?? []);
@@ -88,9 +88,12 @@ public class BackgroundConstantConverter : BackgroundConverter
         foreach (var link in links)
             link.Evaluate(module, behaviour);
 
-        lastUpdateField?.SetValue(module, Planetarium.GetUniversalTime());
-
         return behaviour;
+    }
+
+    public override void OnRestore(PartModule module, ResourceConverter converter)
+    {
+        lastUpdateField?.SetValue(module, Planetarium.GetUniversalTime());
     }
 
     private IEnumerable<ResourceRatio> GetResourceList(

--- a/src/BackgroundResourceProcessing/Converter/BackgroundResourceRelativeConverter.cs
+++ b/src/BackgroundResourceProcessing/Converter/BackgroundResourceRelativeConverter.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using BackgroundResourceProcessing.Behaviour;
+using BackgroundResourceProcessing.Collections;
+using BackgroundResourceProcessing.Utils;
+using ScaledRatio = BackgroundResourceProcessing.Behaviour.ResourceRelativeBehaviour.ScaledRatio;
+
+namespace BackgroundResourceProcessing.Converter;
+
+public class BackgroundResourceRelativeConverter : BackgroundConverter
+{
+    public struct ScaledRatioExpression()
+    {
+        public ResourceRatioExpression ResourceRatio;
+        public ConditionalExpression Fixed = ConditionalExpression.Never;
+
+        public static ScaledRatioExpression Load(Type target, ConfigNode node)
+        {
+            ScaledRatioExpression result = new()
+            {
+                ResourceRatio = ResourceRatioExpression.Load(target, node),
+            };
+            node.TryGetCondition(nameof(Fixed), target, ref result.Fixed);
+
+            return result;
+        }
+
+        public static List<ScaledRatioExpression> LoadList(
+            Type target,
+            ConfigNode node,
+            string nodeName
+        )
+        {
+            var nodes = node.GetNodes(nodeName);
+            List<ScaledRatioExpression> ratios = new(nodes.Length);
+            foreach (var child in nodes)
+                ratios.Add(Load(target, child));
+            return ratios;
+        }
+
+        public bool Evaluate(PartModule module, out ScaledRatio ratio)
+        {
+            if (!ResourceRatio.Evaluate(module, out ResourceRatio resourceRatio))
+            {
+                ratio = default;
+                return false;
+            }
+
+            ratio = new ScaledRatio()
+            {
+                ResourceRatio = resourceRatio,
+                Fixed = Fixed.Evaluate(module),
+            };
+
+            return true;
+        }
+    }
+
+    public List<ScaledRatioExpression> inputs = [];
+    public List<ScaledRatioExpression> outputs = [];
+    public List<ResourceConstraintExpression> required = [];
+
+    public ConditionalExpression ActiveCondition = ConditionalExpression.Always;
+
+    [KSPField]
+    public bool PushToLocalBackgroundInventory = false;
+
+    [KSPField]
+    public bool PullFromLocalBackgroundInventory = false;
+
+    [KSPField]
+    public string LastUpdateField = null;
+
+    /// <summary>
+    /// The name of the resource whose amount is used to determine the other
+    /// rates of this converter.
+    /// </summary>
+    [KSPField]
+    public string RelativeResource;
+
+    /// <summary>
+    /// The resource flow mode that is used to determine which inventories are
+    /// counted when computing the resource amount.
+    /// </summary>
+    [KSPField]
+    public ResourceFlowMode FlowMode = ResourceFlowMode.NULL;
+
+    /// <summary>
+    /// The maximum relative error that this behaviour will allow before
+    /// creating a changepoint.
+    /// </summary>
+    [KSPField]
+    public double MaxError = 0.1;
+
+    /// <summary>
+    /// The minimum amount of time between consecutive changepoints for this
+    /// converter, in seconds.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// This is to prevent infinite changepoints if the resource this behaviour
+    /// depends on is decreasing due to other converters.
+    /// </remarks>
+    [KSPField]
+    public double MinChangepointDelta = 600.0;
+
+    private List<ConverterMultiplier> multipliers = [];
+    private List<LinkExpression> links = [];
+    private MemberAccessor<double>? lastUpdateField = null;
+
+    public override ModuleBehaviour GetBehaviour(PartModule module)
+    {
+        if (!ActiveCondition.Evaluate(module))
+            return null;
+
+        var inputs = this.inputs.TrySelect(
+            (ScaledRatioExpression input, out ScaledRatio value) =>
+                input.Evaluate(module, out value)
+        );
+        var outputs = this.outputs.TrySelect(
+            (ScaledRatioExpression output, out ScaledRatio value) =>
+                output.Evaluate(module, out value)
+        );
+        var required = this.required.TrySelect(
+            (ResourceConstraintExpression req, out ResourceConstraint value) =>
+                req.Evaluate(module, out value)
+        );
+
+        var mult = 1.0;
+        foreach (var field in multipliers)
+            mult *= field.Evaluate(module);
+
+        if (mult != 1.0)
+        {
+            inputs = inputs.Select(input =>
+            {
+                input.Ratio *= mult;
+                return input;
+            });
+            outputs = outputs.Select(output =>
+            {
+                output.Ratio *= mult;
+                return output;
+            });
+        }
+
+        var behaviour = new ModuleBehaviour(
+            new ResourceRelativeBehaviour()
+            {
+                Inputs = [.. inputs],
+                Outputs = [.. outputs],
+                Required = [.. required],
+                ResourceName = RelativeResource,
+                MaxError = MaxError,
+                Connected = GetConnectedResources(module),
+            }
+        );
+
+        if (PushToLocalBackgroundInventory)
+            behaviour.AddPushModule(module);
+        if (PullFromLocalBackgroundInventory)
+            behaviour.AddPullModule(module);
+
+        foreach (var link in links)
+            link.Evaluate(module, behaviour);
+
+        return behaviour;
+    }
+
+    public override void OnRestore(PartModule module, ResourceConverter converter)
+    {
+        lastUpdateField?.SetValue(module, Planetarium.GetUniversalTime());
+    }
+
+    private DynamicBitSet GetConnectedResources(PartModule module)
+    {
+        var part = module.part;
+        var vessel = module.vessel;
+        var processor = vessel.FindVesselModuleImplementing<BackgroundResourceProcessor>();
+        var resourceId = RelativeResource.GetHashCode();
+
+        var flowMode = FlowMode;
+        if (flowMode == ResourceFlowMode.NULL)
+            flowMode = PartResourceLibrary.GetDefaultFlowMode(resourceId);
+
+        DynamicBitSet connected = new(processor.Inventories.Count);
+        PartSet.ResourcePrioritySet partSet = null;
+
+        switch (flowMode)
+        {
+            case ResourceFlowMode.ALL_VESSEL:
+            case ResourceFlowMode.STAGE_PRIORITY_FLOW:
+            case ResourceFlowMode.ALL_VESSEL_BALANCE:
+            case ResourceFlowMode.STAGE_PRIORITY_FLOW_BALANCE:
+                if (vessel == null)
+                    return [];
+
+                partSet = vessel.resourcePartSet.GetResourceList(resourceId, true, false);
+                break;
+
+            case ResourceFlowMode.STACK_PRIORITY_SEARCH:
+            case ResourceFlowMode.STAGE_STACK_FLOW:
+            case ResourceFlowMode.STAGE_STACK_FLOW_BALANCE:
+                partSet = part.crossfeedPartSet.GetResourceList(resourceId, true, false);
+                break;
+
+            default:
+                foreach (var resource in part.Resources.dict.Values)
+                {
+                    if (!resource.flowState)
+                        continue;
+
+                    if (!resource.flowMode.HasFlag(PartResource.FlowMode.Out))
+                        continue;
+
+                    var index = processor.GetInventoryIndex(new(resource));
+                    if (index is null)
+                        continue;
+
+                    connected[(int)index] = true;
+                }
+
+                break;
+        }
+
+        if (partSet != null)
+        {
+            foreach (var item in GetNestedEnumerator(partSet.lists))
+            {
+                var index = processor.GetInventoryIndex(new(item));
+                if (index == null)
+                    continue;
+
+                connected[(int)index] = true;
+            }
+        }
+
+        foreach (var link in links)
+        {
+            if (!link.Relation.HasFlag(LinkExpression.LinkRelation.REQUIRED))
+                continue;
+            if (!link.condition.Evaluate(module))
+                continue;
+            if (!link.Target.TryEvaluate(module, out var target))
+                continue;
+            if (target == null)
+                continue;
+
+            var index = processor.GetInventoryIndex(new(target, RelativeResource));
+            if (index == null)
+                continue;
+
+            connected[(int)index] = true;
+        }
+
+        return connected;
+    }
+
+    protected override void OnLoad(ConfigNode node)
+    {
+        base.OnLoad(node);
+
+        var target = GetTargetType(node);
+
+        node.TryGetCondition(nameof(ActiveCondition), target, ref ActiveCondition);
+
+        multipliers = ConverterMultiplier.LoadAll(target, node);
+        links = LinkExpression.LoadList(target, node);
+
+        inputs.AddRange(ScaledRatioExpression.LoadList(target, node, "INPUT_RESOURCE"));
+        outputs.AddRange(ScaledRatioExpression.LoadList(target, node, "OUTPUT_RESOURCE"));
+        required.AddRange(ResourceConstraintExpression.LoadRequirements(target, node));
+
+        if (LastUpdateField != null)
+            lastUpdateField = new(target, LastUpdateField, MemberAccessor<double>.Access.Write);
+    }
+
+    private static NestedListEnumerator<T> GetNestedEnumerator<T>(List<List<T>> list) => new(list);
+
+    private struct NestedListEnumerator<T>(List<List<T>> list) : IEnumerator<T>
+    {
+        private static readonly List<T> Empty = [];
+
+        List<List<T>>.Enumerator outer = list.GetEnumerator();
+        List<T>.Enumerator inner = Empty.GetEnumerator();
+
+        public T Current => inner.Current;
+        object IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            while (true)
+            {
+                if (inner.MoveNext())
+                    return true;
+
+                inner.Dispose();
+
+                if (!outer.MoveNext())
+                {
+                    inner = Empty.GetEnumerator();
+                    return false;
+                }
+
+                inner = outer.Current.GetEnumerator();
+            }
+        }
+
+        void IEnumerator.Reset() => throw new NotImplementedException();
+
+        public void Dispose()
+        {
+            inner.Dispose();
+            outer.Dispose();
+        }
+
+        public readonly NestedListEnumerator<T> GetEnumerator() => this;
+    }
+}

--- a/src/BackgroundResourceProcessing/Core/ResourceProcessor.cs
+++ b/src/BackgroundResourceProcessing/Core/ResourceProcessor.cs
@@ -270,13 +270,12 @@ internal class ResourceProcessor
     }
 
     #region Vessel Recording
-    public void RecordVesselState(Vessel vessel, double currentTime)
+    public void RecordVesselState(Vessel vessel, VesselState state)
     {
         using var span = new TraceSpan("ResourceProcessor.RecordVesselState");
 
         ClearVesselState();
-        var state = new VesselState(currentTime);
-        lastUpdate = currentTime;
+        lastUpdate = state.CurrentTime;
 
         LogUtil.Debug(() => $"Recording vessel state for vessel {vessel.GetDisplayName()}");
 

--- a/src/BackgroundResourceProcessing/ResourceConstraint.cs
+++ b/src/BackgroundResourceProcessing/ResourceConstraint.cs
@@ -22,7 +22,7 @@ public enum Constraint
 /// A constraint applied to a resource.
 /// </summary>
 [DebuggerDisplay("{Constraint} {Amount} {ResourceName}")]
-public struct ResourceConstraint()
+public struct ResourceConstraint() : ConfigUtil.IConfigLoadable
 {
     /// <summary>
     /// The name of the resource that this constraint applies to.

--- a/src/BackgroundResourceProcessing/UI/DebugUI.Converter.cs
+++ b/src/BackgroundResourceProcessing/UI/DebugUI.Converter.cs
@@ -341,8 +341,12 @@ internal partial class DebugUI
                     return;
                 }
 
-                var state = new VesselState();
-                state.SetShadowState(ShadowState.GetShadowState(module.vessel));
+                var state = new VesselState()
+                {
+                    ShadowState = ShadowState.GetShadowState(module.vessel),
+                    Processor =
+                        module.vessel.FindVesselModuleImplementing<BackgroundResourceProcessor>(),
+                };
 
                 foreach (var converter in behaviour.Converters)
                 {

--- a/src/BackgroundResourceProcessing/Utils/ConfigUtil.cs
+++ b/src/BackgroundResourceProcessing/Utils/ConfigUtil.cs
@@ -174,4 +174,33 @@ public static class ConfigUtil
 
         return false;
     }
+
+    public interface IConfigLoadable
+    {
+        void Load(ConfigNode node);
+        void Save(ConfigNode node);
+    }
+
+    public static List<T> LoadNodeList<T>(ConfigNode node, string nodeName)
+        where T : IConfigLoadable
+    {
+        var nodes = node.GetNodes(nodeName);
+        var list = new List<T>(nodes.Length);
+
+        foreach (var child in nodes)
+        {
+            T item = Activator.CreateInstance<T>();
+            item.Load(child);
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+    public static void SaveNodeList<T>(ConfigNode node, string nodeName, IEnumerable<T> items)
+        where T : IConfigLoadable
+    {
+        foreach (var item in items)
+            item.Save(node.AddNode(nodeName));
+    }
 }

--- a/src/BackgroundResourceProcessing/Utils/FieldExpression.Builtins.cs
+++ b/src/BackgroundResourceProcessing/Utils/FieldExpression.Builtins.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace BackgroundResourceProcessing.Utils;
+
+internal partial struct FieldExpression
+{
+    internal class Settings
+    {
+        internal static readonly Settings Instance = new();
+
+        public SectionSettings this[string section]
+        {
+            get
+            {
+                var parameters = HighLogic.CurrentGame?.Parameters;
+                if (parameters == null)
+                    return null;
+
+                var selected = GetCustomParams(parameters)
+                    .Values.Where(node => node.Section == section);
+
+                return new(selected);
+            }
+        }
+
+        private Settings() { }
+
+        private static readonly FieldInfo CustomParamsField = typeof(GameParameters).GetField(
+            "customParams",
+            Flags
+        );
+
+        private static Dictionary<Type, GameParameters.CustomParameterNode> GetCustomParams(
+            GameParameters parameters
+        )
+        {
+            return (Dictionary<Type, GameParameters.CustomParameterNode>)
+                CustomParamsField.GetValue(parameters);
+        }
+    };
+
+    internal class SectionSettings(IEnumerable<GameParameters.CustomParameterNode> nodes)
+    {
+        internal GameParameters.CustomParameterNode this[string name] =>
+            nodes.Where(node => node.GetType().Name == name || node.Title == name).FirstOrDefault();
+    }
+
+    internal class Builtins
+    {
+        internal static readonly Builtins Instance = new();
+
+        public Settings Settings => Settings.Instance;
+        public MathBuiltins Math => MathBuiltins.Instance;
+
+        public double Infinity => double.PositiveInfinity;
+    }
+}

--- a/src/BackgroundResourceProcessing/Utils/FieldExpression.MathBuiltins.cs
+++ b/src/BackgroundResourceProcessing/Utils/FieldExpression.MathBuiltins.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace BackgroundResourceProcessing.Utils;
+
+internal partial struct FieldExpression
+{
+    /// <summary>
+    /// A builtin object that exposes values within the Math class for use
+    /// in field expressions.
+    /// </summary>
+    internal class MathBuiltins
+    {
+        internal static readonly MathBuiltins Instance = new();
+
+        public double PI => Math.PI;
+        public double E => Math.E;
+
+        public double Abs(double v) => Math.Abs(v);
+
+        public double Sign(double v) => Math.Sign(v);
+
+        public double Ceiling(double x) => Math.Ceiling(x);
+
+        public double Floor(double x) => Math.Floor(x);
+
+        public double Round(double x) => Math.Round(x);
+
+        public double Truncate(double x) => Math.Truncate(x);
+
+        public double Acos(double d) => Math.Acos(d);
+
+        public double Asin(double d) => Math.Asin(d);
+
+        public double Atan(double d) => Math.Atan(d);
+
+        public double Atan2(double y, double x) => Math.Atan2(y, x);
+
+        public double Sin(double x) => Math.Sin(x);
+
+        public double Cos(double x) => Math.Cos(x);
+
+        public double Tan(double x) => Math.Tan(x);
+
+        public double Cosh(double x) => Math.Cosh(x);
+
+        public double Sinh(double x) => Math.Sinh(x);
+
+        public double Tanh(double x) => Math.Tanh(x);
+
+        public double Sqrt(double x) => Math.Sqrt(x);
+
+        public double Pow(double x, double y) => Math.Pow(x, y);
+
+        public double Exp(double x) => Math.Exp(x);
+
+        public double Log(double x) => Math.Log(x);
+
+        public double Log10(double x) => Math.Log10(x);
+
+        public double Max(double a, double b) => Math.Max(a, b);
+
+        public double Min(double a, double b) => Math.Min(a, b);
+    }
+}

--- a/src/BackgroundResourceProcessing/Utils/FieldExpression.Parsing.cs
+++ b/src/BackgroundResourceProcessing/Utils/FieldExpression.Parsing.cs
@@ -50,6 +50,11 @@ internal partial struct FieldExpression
             try
             {
                 var member = type.GetMethod(method, Flags, null, ptypes, []);
+                if (member == null)
+                    throw new Exception(
+                        $"There is no method {type.Name}.{method}({string.Join(", ", ptypes.Select(t => t.Name))})"
+                    );
+
                 return member.Invoke(obj, parameters);
             }
             catch (Exception e)

--- a/src/BackgroundResourceProcessing/Utils/FieldExpression.Parsing.cs
+++ b/src/BackgroundResourceProcessing/Utils/FieldExpression.Parsing.cs
@@ -880,12 +880,13 @@ internal partial struct FieldExpression
                 ExpectToken(TokenKind.LPAREN);
                 while (true)
                 {
+                    if (Current == TokenKind.RPAREN)
+                        break;
+
                     args.Add(ParseExpression());
 
                     if (Current == TokenKind.COMMA)
                         lexer.MoveNext();
-                    if (Current == TokenKind.RPAREN)
-                        break;
                 }
                 ExpectToken(TokenKind.RPAREN);
 

--- a/src/BackgroundResourceProcessing/Utils/FieldExpression.Parsing.cs
+++ b/src/BackgroundResourceProcessing/Utils/FieldExpression.Parsing.cs
@@ -3,11 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Runtime.Remoting.Messaging;
-using Contracts;
-using UnityEngine.Rendering;
-using UnityEngine.Windows.Speech;
 
 namespace BackgroundResourceProcessing.Utils;
 
@@ -15,7 +10,7 @@ public class EvaluationException(string message) : Exception(message) { }
 
 public class CompilationException(string message) : Exception(message) { }
 
-internal struct FieldExpression
+internal partial struct FieldExpression
 {
     const BindingFlags Flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 
@@ -24,58 +19,6 @@ internal struct FieldExpression
     {
         const BindingFlags Flags =
             BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
-
-        internal class Settings
-        {
-            internal static readonly Settings Instance = new();
-
-            public SectionSettings this[string section]
-            {
-                get
-                {
-                    var parameters = HighLogic.CurrentGame?.Parameters;
-                    if (parameters == null)
-                        return null;
-
-                    var selected = GetCustomParams(parameters)
-                        .Values.Where(node => node.Section == section);
-
-                    return new(selected);
-                }
-            }
-
-            private Settings() { }
-
-            private static readonly FieldInfo CustomParamsField = typeof(GameParameters).GetField(
-                "customParams",
-                Flags
-            );
-
-            private static Dictionary<Type, GameParameters.CustomParameterNode> GetCustomParams(
-                GameParameters parameters
-            )
-            {
-                return (Dictionary<Type, GameParameters.CustomParameterNode>)
-                    CustomParamsField.GetValue(parameters);
-            }
-        };
-
-        internal class SectionSettings(IEnumerable<GameParameters.CustomParameterNode> nodes)
-        {
-            internal GameParameters.CustomParameterNode this[string name] =>
-                nodes
-                    .Where(node => node.GetType().Name == name || node.Title == name)
-                    .FirstOrDefault();
-        }
-
-        internal class Builtins
-        {
-            internal static readonly Builtins Instance = new();
-
-            public Settings Settings => Settings.Instance;
-
-            public double Infinity => double.PositiveInfinity;
-        }
 
         public static object DoFieldAccess(object obj, string member)
         {
@@ -978,7 +921,7 @@ internal struct FieldExpression
         {
             ExpectToken(TokenKind.OP_BUILTIN_ACCESS);
 
-            var builtins = Expression.Constant(Methods.Builtins.Instance);
+            var builtins = Expression.Constant(Builtins.Instance);
             switch (Current.kind)
             {
                 case TokenKind.IDENT:

--- a/src/BackgroundResourceProcessing/Utils/LinkExpression.cs
+++ b/src/BackgroundResourceProcessing/Utils/LinkExpression.cs
@@ -8,15 +8,19 @@ public struct LinkExpression()
 {
     public enum LinkRelation
     {
-        PUSH,
-        PULL,
-        REQUIRED,
-        INVALID,
+        INVALID = 0,
+
+        PUSH = 0x1,
+        PULL = 0x2,
+        REQUIRED = 0x4,
+
+        PUSH_AND_PULL = 0x3,
+        ALL = 0x7,
     }
 
     public ConditionalExpression condition = ConditionalExpression.Always;
 
-    public LinkRelation Relation = LinkRelation.PUSH;
+    public LinkRelation Relation = LinkRelation.INVALID;
 
     public FieldExpression<PartModule> Target = new();
 
@@ -27,21 +31,17 @@ public struct LinkExpression()
 
         if (!Target.TryEvaluate(module, out var target))
             return;
+        if (target == null)
+            return;
 
-        switch (Relation)
-        {
-            case LinkRelation.PUSH:
-                behaviour.AddPushModule(target);
-                break;
+        if (Relation.HasFlag(LinkRelation.PUSH))
+            behaviour.AddPushModule(target);
 
-            case LinkRelation.PULL:
-                behaviour.AddPullModule(target);
-                break;
+        if (Relation.HasFlag(LinkRelation.PULL))
+            behaviour.AddPullModule(target);
 
-            case LinkRelation.REQUIRED:
-                behaviour.AddConstraintModule(target);
-                break;
-        }
+        if (Relation.HasFlag(LinkRelation.REQUIRED))
+            behaviour.AddConstraintModule(target);
     }
 
     public static LinkExpression Load(Type target, ConfigNode node)

--- a/src/BackgroundResourceProcessing/Utils/LinkExpression.cs
+++ b/src/BackgroundResourceProcessing/Utils/LinkExpression.cs
@@ -26,11 +26,7 @@ public struct LinkExpression()
 
     public readonly void Evaluate(PartModule module, ModuleBehaviour behaviour)
     {
-        if (!condition.Evaluate(module))
-            return;
-
-        if (!Target.TryEvaluate(module, out var target))
-            return;
+        var target = EvaluateTarget(module);
         if (target == null)
             return;
 
@@ -42,6 +38,17 @@ public struct LinkExpression()
 
         if (Relation.HasFlag(LinkRelation.REQUIRED))
             behaviour.AddConstraintModule(target);
+    }
+
+    public readonly PartModule EvaluateTarget(PartModule module)
+    {
+        if (!condition.Evaluate(module))
+            return null;
+
+        if (!Target.TryEvaluate(module, out var target))
+            return null;
+
+        return target;
     }
 
     public static LinkExpression Load(Type target, ConfigNode node)

--- a/src/BackgroundResourceProcessing/VesselState.cs
+++ b/src/BackgroundResourceProcessing/VesselState.cs
@@ -1,3 +1,4 @@
+using System;
 using BackgroundResourceProcessing.Utils;
 
 namespace BackgroundResourceProcessing;
@@ -24,16 +25,13 @@ public class VesselState(double CurrentTime)
     /// </remarks>
     public readonly double CurrentTime = CurrentTime;
 
-    public ShadowState ShadowState { get; private set; } = ShadowState.AlwaysInShadow();
+    public ShadowState ShadowState = ShadowState.AlwaysInShadow();
+
+    public BackgroundResourceProcessor Processor = null;
 
     /// <summary>
     /// Create a <c><see cref="VesselState"/></c> with the current time.
     /// </summary>
     public VesselState()
         : this(Planetarium.GetUniversalTime()) { }
-
-    public void SetShadowState(ShadowState state)
-    {
-        ShadowState = state;
-    }
 }

--- a/src/GameData/Config/Squad.cfg
+++ b/src/GameData/Config/Squad.cfg
@@ -115,17 +115,6 @@ RESOURCE_DEFINITION
     volume = 1
 }
 
-// BACKGROUND_CONVERTER
-// {
-//     name = ModuleScienceConverter
-//     adapter = BackgroundScienceConverter
-
-//     DataResourceName = BRPScienceLabData
-//     ScienceResourceName = BRPScience
-
-//     MaxError = 0.1
-// }
-
 BACKGROUND_CONVERTER
 {
     name = ModuleScienceConverter

--- a/src/GameData/Config/Squad.cfg
+++ b/src/GameData/Config/Squad.cfg
@@ -149,19 +149,19 @@ BACKGROUND_CONVERTER
     INPUT_RESOURCE
     {
         ResourceName = BRPScienceLabData
-        Ratio = %dataProcessingMultiplier * %.GetScientists() / $Math.Pos(10, %researchTime)
+        Ratio = %dataProcessingMultiplier * %.GetScientists() / $Math.Pow(10, %researchTime)
         FlowMode = NO_FLOW
     }
 
     OUTPUT_RESOURCE
     {
         ResourceName = BRPScience
-        Ratio = %scienceMultiplier * %dataProcessingMultiplier * %.GetScientists() / $Math.Pos(10, %researchTime)
+        Ratio = %scienceMultiplier * %dataProcessingMultiplier * %.GetScientists() / $Math.Pow(10, %researchTime)
         FlowMode = NO_FLOW
         DumpExcess = false
     }
 
-    LINK_INVENTORY
+    INVENTORY_LINK
     {
         Relation = ALL
         Target = %Lab

--- a/src/GameData/Config/Squad.cfg
+++ b/src/GameData/Config/Squad.cfg
@@ -115,15 +115,57 @@ RESOURCE_DEFINITION
     volume = 1
 }
 
+// BACKGROUND_CONVERTER
+// {
+//     name = ModuleScienceConverter
+//     adapter = BackgroundScienceConverter
+
+//     DataResourceName = BRPScienceLabData
+//     ScienceResourceName = BRPScience
+
+//     MaxError = 0.1
+// }
+
 BACKGROUND_CONVERTER
 {
     name = ModuleScienceConverter
-    adapter = BackgroundScienceConverter
+    adapter = BackgroundResourceRelativeConverter
 
-    DataResourceName = BRPScienceLabData
-    ScienceResourceName = BRPScience
+    ActiveCondition = %IsActivated
+
+    RelativeResource = BRPScienceLabData
+    FlowMode = NO_FLOW
 
     MaxError = 0.1
+
+    INPUT_RESOURCE
+    {
+        ResourceName = ElectricCharge
+        Ratio = %powerRequirement
+        FlowMode = ALL_VESSEL
+        Fixed = true
+    }
+
+    INPUT_RESOURCE
+    {
+        ResourceName = BRPScienceLabData
+        Ratio = %dataProcessingMultiplier * %.GetScientists() / $Math.Pos(10, %researchTime)
+        FlowMode = NO_FLOW
+    }
+
+    OUTPUT_RESOURCE
+    {
+        ResourceName = BRPScience
+        Ratio = %scienceMultiplier * %dataProcessingMultiplier * %.GetScientists() / $Math.Pos(10, %researchTime)
+        FlowMode = NO_FLOW
+        DumpExcess = false
+    }
+
+    LINK_INVENTORY
+    {
+        Relation = ALL
+        Target = %Lab
+    }
 }
 
 BACKGROUND_INVENTORY

--- a/test/BackgroundResourceProcessing.Test/Utils/FieldExpression.cs
+++ b/test/BackgroundResourceProcessing.Test/Utils/FieldExpression.cs
@@ -49,6 +49,8 @@ public sealed class FieldExpressionTests
     class FloatCurveTest : PartModule
     {
         public double Evaluate(double value) => value;
+
+        public double NoParams() => 1.0;
     }
 
     [TestMethod]
@@ -58,5 +60,13 @@ public sealed class FieldExpressionTests
 
         var expr = FieldExpression<double>.Compile("%.Evaluate(75)", new(), typeof(FloatCurveTest));
         Assert.AreEqual(75.0, expr.Evaluate(module));
+    }
+
+    [TestMethod]
+    public void EvaluateNoParams()
+    {
+        FloatCurveTest module = new();
+        var expr = FieldExpression<double>.Compile("%.NoParams()", new(), typeof(FloatCurveTest));
+        Assert.AreEqual(1.0, expr.Evaluate(module));
     }
 }


### PR DESCRIPTION
This is a pretty common pattern that shows up in lots of exponential decay-type part modules: science labs, boiloff, and more. This PR introduces a generic background converter module and behaviour that is capable of handling pretty much all the use cases I have seen so far (except CryoTanks, because the same part module can handled multiple independent resources)