### PR TITLE
Switch everything we can to use KSPAssemblyDependency

### DIFF
--- a/src/BackgroundResourceProcessing.Integration.AutomaticLabHousekeeper/BackgroundResourceProcessing.Integration.AutomaticLabHousekeeper.csproj
+++ b/src/BackgroundResourceProcessing.Integration.AutomaticLabHousekeeper/BackgroundResourceProcessing.Integration.AutomaticLabHousekeeper.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -27,6 +27,8 @@
         <Reference Include="AutomaticLabHousekeeper.dll">
             <HintPath>$(DepSet1)\AutomaticLabHousekeeper\AutomaticLabHousekeeper.dll</HintPath>
             <Private>false</Private>
+            <KSPAssemblyName>AutomaticLabHousekeeper</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.BackgroundResources/BackgroundResourceProcessing.Integration.BackgroundResources.csproj
+++ b/src/BackgroundResourceProcessing.Integration.BackgroundResources/BackgroundResourceProcessing.Integration.BackgroundResources.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -28,6 +28,8 @@
             <HintPath>$(DepSet2)\REPOSoftTech\BackgroundResources\BackgroundResources.dll</HintPath>
             <Private>false</Private>
             <CKANIdentifier>BackgroundResources</CKANIdentifier>
+            <KSPAssemblyName>BackgroundResources</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.CryoTanks/BackgroundResourceProcessing.Integration.CryoTanks.csproj
+++ b/src/BackgroundResourceProcessing.Integration.CryoTanks/BackgroundResourceProcessing.Integration.CryoTanks.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -20,6 +20,8 @@
             <HintPath>$(DepSet1)\CryoTanks\Plugins\SimpleBoiloff.dll</HintPath>
             <Private>false</Private>
             <CKANIdentifier>CryoTanksCore</CKANIdentifier>
+            <KSPAssemblyName>SimpleBoiloff</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.EL/BackgroundResourceProcessing.Integration.EL.csproj
+++ b/src/BackgroundResourceProcessing.Integration.EL/BackgroundResourceProcessing.Integration.EL.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -20,6 +20,7 @@
             <HintPath>$(DepSet1)\ExtraplanetaryLaunchpads\Plugins\Launchpad.dll</HintPath>
             <Private>false</Private>
             <KSPAssemblyName>Launchpad</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.NearFutureSolar/BackgroundResourceProcessing.Integration.NearFutureSolar.csproj
+++ b/src/BackgroundResourceProcessing.Integration.NearFutureSolar/BackgroundResourceProcessing.Integration.NearFutureSolar.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -20,6 +20,8 @@
             <HintPath>$(DepSet1)\NearFutureSolar\Plugins\NearFutureSolar.dll</HintPath>
             <Private>false</Private>
             <CKANIdentifier>NearFutureSolar-Core</CKANIdentifier>
+            <KSPAssemblyName>NearFutureSolar</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.Snacks/BackgroundResourceProcessing.Integration.Snacks.csproj
+++ b/src/BackgroundResourceProcessing.Integration.Snacks/BackgroundResourceProcessing.Integration.Snacks.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -27,6 +27,8 @@
         <Reference Include="SnacksUtils.dll">
             <HintPath>$(DepSet1)\WildBlueIndustries\Snacks\Plugin\SnacksUtils.dll</HintPath>
             <Private>false</Private>
+            <KSPAssemblyName>Snacks</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.SpaceDust/BackgroundResourceProcessing.Integration.SpaceDust.csproj
+++ b/src/BackgroundResourceProcessing.Integration.SpaceDust/BackgroundResourceProcessing.Integration.SpaceDust.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -27,6 +27,8 @@
         <Reference Include="SpaceDust.dll">
             <HintPath>$(DepSet1)\SpaceDust\Plugins\SpaceDust.dll</HintPath>
             <Private>false</Private>
+            <KSPAssemblyName>SpaceDust</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.SystemHeat/BackgroundResourceProcessing.Integration.SystemHeat.csproj
+++ b/src/BackgroundResourceProcessing.Integration.SystemHeat/BackgroundResourceProcessing.Integration.SystemHeat.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -25,6 +25,8 @@
             <HintPath>$(DepSet1)\SystemHeat\Plugin\SystemHeat.dll</HintPath>
             <Private>false</Private>
             <CKANIdentifier>SystemHeat</CKANIdentifier>
+            <KSPAssemblyName>SystemHeat</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.TACLifeSupport/BackgroundResourceProcessing.Integration.TACLifeSupport.csproj
+++ b/src/BackgroundResourceProcessing.Integration.TACLifeSupport/BackgroundResourceProcessing.Integration.TACLifeSupport.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -28,6 +28,8 @@
             <HintPath>$(DepSet2)\ThunderAerospace\TacLifeSupport\Plugins\TacLifeSupport.dll</HintPath>
             <Private>false</Private>
             <CKANIdentifier>TAC-LS</CKANIdentifier>
+            <KSPAssemblyName>TacLifeSupport</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.USILifeSupport/BackgroundResourceProcessing.Integration.USILifeSupport.csproj
+++ b/src/BackgroundResourceProcessing.Integration.USILifeSupport/BackgroundResourceProcessing.Integration.USILifeSupport.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -28,6 +28,15 @@
             <HintPath>$(DepSet1)\UmbraSpaceIndustries\LifeSupport\USILifeSupport.dll</HintPath>
             <Private>false</Private>
             <CKANIdentifier>USI-LS</CKANIdentifier>
+            <KSPAssemblyName>USILifeSupport</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
+        </Reference>
+
+        <Reference Include="USITools.dll">
+            <HintPath>$(DepSet1)\000_USITools\USITools.dll</HintPath>
+            <Private>false</Private>
+            <KSPAssemblyName>USITools</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.WBIResources/BackgroundResourceProcessing.Integration.WBIResources.csproj
+++ b/src/BackgroundResourceProcessing.Integration.WBIResources/BackgroundResourceProcessing.Integration.WBIResources.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -32,6 +32,8 @@
         <Reference Include="WBIResources">
             <HintPath>$(DepSet1)\WildBlueIndustries\0WBIResources\Plugins\WBIResources.dll</HintPath>
             <Private>false</Private>
+            <KSPAssemblyName>WBIResources</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing.Integration.WildBlueTools/BackgroundResourceProcessing.Integration.WildBlueTools.csproj
+++ b/src/BackgroundResourceProcessing.Integration.WildBlueTools/BackgroundResourceProcessing.Integration.WildBlueTools.csproj
@@ -5,7 +5,7 @@
         <GenerateKSPAssemblyAttribute>true</GenerateKSPAssemblyAttribute>
         <GenerateKSPAssemblyDependencyAttributes>true</GenerateKSPAssemblyDependencyAttributes>
 
-        <KSPBinaryType>plugin</KSPBinaryType>
+        <KSPBinaryType>binary</KSPBinaryType>
     </PropertyGroup>
 
     <ItemGroup>
@@ -27,6 +27,8 @@
         <Reference Include="WildBlueTools.dll">
             <HintPath>$(DepSet1)\WildBlueIndustries\000WildBlueTools\Plugins\WildBlueTools.dll</HintPath>
             <Private>false</Private>
+            <KSPAssemblyName>WildBlueTools</KSPAssemblyName>
+            <KSPAssemblyVersion>0.0.0</KSPAssemblyVersion>
         </Reference>
 
         <InternalsVisibleTo Include="BackgroundResourceProcessing.Test" />

--- a/src/BackgroundResourceProcessing/Addons/Loader.cs
+++ b/src/BackgroundResourceProcessing/Addons/Loader.cs
@@ -22,63 +22,11 @@ internal sealed class BackgroundResourceProcessingLoader : MonoBehaviour
     private static readonly Dictionary<string, List<AssemblyDependency>> Dependencies =
     [
         new(
-            "BackgroundResourceProcessing.Integration.AutomaticLabHousekeeper",
-            [new DirectAssemblyDependency("AutomaticLabHousekeeper", new(1, 0))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.BackgroundResources",
-            [new DirectAssemblyDependency("BackgroundResources", new(1, 12))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.CryoTanks",
-            [new DirectAssemblyDependency("SimpleBoiloff", new(0, 2))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.DeepFreeze",
-            [new KSPAssemblyDependency("DeepFreeze", new(0, 31))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.EL",
-            [new DirectAssemblyDependency("Launchpad", new(6, 99))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.NearFutureSolar",
-            [new DirectAssemblyDependency("NearFutureSolar", new(0, 4))]
-        ),
-        new(
             "BackgroundResourceProcessing.Integration.PersistentThrust.17",
             [
                 new DirectAssemblyDependency("PersistentThrust", new(1, 7, 5)),
                 new DirectAssemblyMaxVersion("PersistentThrust", new(1, 8)),
             ]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.SpaceDust",
-            [new DirectAssemblyDependency("SpaceDust", new(0, 5, 4))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.Snacks",
-            [new DirectAssemblyDependency("Snacks", new(1, 0))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.SystemHeat",
-            [new DirectAssemblyDependency("SystemHeat", new(0, 1))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.TACLifeSupport",
-            [new DirectAssemblyDependency("TacLifeSupport", new(0, 18))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.USILifeSupport",
-            [new DirectAssemblyDependency("USILifeSupport", new(1, 0))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.WildBlueTools",
-            [new DirectAssemblyDependency("WildBlueTools", new(1, 0))]
-        ),
-        new(
-            "BackgroundResourceProcessing.Integration.WBIResources",
-            [new DirectAssemblyDependency("WBIResources", new(1, 0))]
         ),
     ];
 


### PR DESCRIPTION
This means that these can be used with the hot reload plugin, and also other mods can depend on them if they need.