### PR TITLE
Avoid hot-reload deleting its own patches

### DIFF
--- a/src/BackgroundResourceProcessing.Integration.AutomaticLabHousekeeper/AutomaticLabHousekeeperPatch.cs
+++ b/src/BackgroundResourceProcessing.Integration.AutomaticLabHousekeeper/AutomaticLabHousekeeperPatch.cs
@@ -18,9 +18,10 @@ public class Loader : MonoBehaviour
         harmony.PatchAll(typeof(Loader).Assembly);
     }
 
-    static void OnHotUnload()
+    static void OnHotLoad()
     {
         harmony.UnpatchAll(harmony.Id);
+        harmony.PatchAll(typeof(Loader).Assembly);
     }
 }
 

--- a/src/BackgroundResourceProcessing.Integration.BackgroundResources/Loader.cs
+++ b/src/BackgroundResourceProcessing.Integration.BackgroundResources/Loader.cs
@@ -26,9 +26,10 @@ public class Loader : MonoBehaviour
         );
     }
 
-    static void OnHotUnload()
+    static void OnHotLoad()
     {
         harmony.UnpatchAll(harmony.Id);
+        harmony.PatchAll(typeof(Loader).Assembly);
     }
 }
 

--- a/src/BackgroundResourceProcessing.Integration.BonVoyage/Loader.cs
+++ b/src/BackgroundResourceProcessing.Integration.BonVoyage/Loader.cs
@@ -15,8 +15,9 @@ public class Loader : MonoBehaviour
         harmony.PatchAll(typeof(Loader).Assembly);
     }
 
-    static void OnHotUnload()
+    static void OnHotLoad()
     {
         harmony.UnpatchAll(harmony.Id);
+        harmony.PatchAll(typeof(Loader).Assembly);
     }
 }

--- a/src/BackgroundResourceProcessing.Integration.Snacks/Loader.cs
+++ b/src/BackgroundResourceProcessing.Integration.Snacks/Loader.cs
@@ -15,8 +15,9 @@ public class Loader : MonoBehaviour
         harmony.PatchAll(typeof(Loader).Assembly);
     }
 
-    static void OnHotUnload()
+    static void OnHotLoad()
     {
         harmony.UnpatchAll(harmony.Id);
+        harmony.PatchAll(typeof(Loader).Assembly);
     }
 }

--- a/src/BackgroundResourceProcessing.Integration.SpaceDust/SpaceDustHarvesterBackgroundPatch.cs
+++ b/src/BackgroundResourceProcessing.Integration.SpaceDust/SpaceDustHarvesterBackgroundPatch.cs
@@ -18,9 +18,10 @@ public class Loader : MonoBehaviour
         harmony.PatchAll(typeof(Loader).Assembly);
     }
 
-    static void OnHotUnload()
+    static void OnHotLoad()
     {
         harmony.UnpatchAll(harmony.Id);
+        harmony.PatchAll(typeof(Loader).Assembly);
     }
 }
 

--- a/src/BackgroundResourceProcessing.Integration.TACLifeSupport/Loader.cs
+++ b/src/BackgroundResourceProcessing.Integration.TACLifeSupport/Loader.cs
@@ -15,8 +15,9 @@ public class Loader : MonoBehaviour
         harmony.PatchAll(typeof(Loader).Assembly);
     }
 
-    static void OnHotUnload()
+    static void OnHotLoad()
     {
         harmony.UnpatchAll(harmony.Id);
+        harmony.PatchAll(typeof(Loader).Assembly);
     }
 }

--- a/src/BackgroundResourceProcessing.Integration.USILifeSupport/LifeSupportMonitorPatch.cs
+++ b/src/BackgroundResourceProcessing.Integration.USILifeSupport/LifeSupportMonitorPatch.cs
@@ -23,9 +23,10 @@ public class Loader : MonoBehaviour
         harmony.PatchAll(typeof(Loader).Assembly);
     }
 
-    static void OnHotUnload()
+    static void OnHotLoad()
     {
         harmony.UnpatchAll(harmony.Id);
+        harmony.PatchAll(typeof(Loader).Assembly);
     }
 }
 

--- a/src/BackgroundResourceProcessing.Integration.WBIResources/Loader.cs
+++ b/src/BackgroundResourceProcessing.Integration.WBIResources/Loader.cs
@@ -15,8 +15,9 @@ public class Loader : MonoBehaviour
         harmony.PatchAll(typeof(Loader).Assembly);
     }
 
-    static void OnHotUnload()
+    static void OnHotLoad()
     {
         harmony.UnpatchAll(harmony.Id);
+        harmony.PatchAll(typeof(Loader).Assembly);
     }
 }

--- a/src/BackgroundResourceProcessing.Integration.WildBlueTools/Loader.cs
+++ b/src/BackgroundResourceProcessing.Integration.WildBlueTools/Loader.cs
@@ -15,8 +15,9 @@ public class Loader : MonoBehaviour
         harmony.PatchAll(typeof(Loader).Assembly);
     }
 
-    static void OnHotUnload()
+    static void OnHotLoad()
     {
         harmony.UnpatchAll(harmony.Id);
+        harmony.PatchAll(typeof(Loader).Assembly);
     }
 }


### PR DESCRIPTION
OnHotUnload happens after OnHotLoad, so it ends up removing the new assembly's patches.