### PR TITLE
Automatically import existing resource inventories into BRP

### DIFF
--- a/src/BackgroundResourceProcessing/BackgroundResourceProcessor.Internals.cs
+++ b/src/BackgroundResourceProcessing/BackgroundResourceProcessor.Internals.cs
@@ -47,11 +47,21 @@ public sealed partial class BackgroundResourceProcessor
         {
             LoadVessel();
         }
+        else if (
+            !Initialized
+            && processor.inventories.Count == 0
+            && processor.converters.Count == 0
+        )
+        {
+            processor.InitializeProtoInventories(vessel);
+        }
         else
         {
             processor.RecordProtoInventories(vessel);
             EventDispatcher.RegisterChangepointCallback(this, processor.nextChangepoint);
         }
+
+        Initialized = true;
     }
 
     void OnDestroy()

--- a/src/BackgroundResourceProcessing/BackgroundResourceProcessor.cs
+++ b/src/BackgroundResourceProcessing/BackgroundResourceProcessor.cs
@@ -28,6 +28,9 @@ public sealed partial class BackgroundResourceProcessor : VesselModule
 
     private bool IsDirty = false;
 
+    [KSPField(isPersistant = true)]
+    private bool Initialized = false;
+
     private bool ImmediateChangepointRequested = false;
 
     private BurstSolver.ShadowHandle pendingShadow;

--- a/src/BackgroundResourceProcessing/Core/ResourceProcessor.cs
+++ b/src/BackgroundResourceProcessing/Core/ResourceProcessor.cs
@@ -555,6 +555,51 @@ internal class ResourceProcessor
         inventoryIds.Clear();
         nextChangepoint = double.PositiveInfinity;
     }
+
+    /// <summary>
+    /// Populate inventories from an unloaded vessel's proto part snapshots.
+    /// </summary>
+    ///
+    /// <remarks>
+    /// Only stock <see cref="ProtoPartResourceSnapshot"/>s are handled here;
+    /// module-backed fake inventories need a live <see cref="PartModule"/>
+    /// and will populate the first time the vessel is loaded and unloaded.
+    /// </remarks>
+    public void InitializeProtoInventories(Vessel vessel)
+    {
+        using var span = new TraceSpan("ResourceProcessor.InitializeProtoInventories");
+
+        lastUpdate = Planetarium.GetUniversalTime();
+        nextChangepoint = double.PositiveInfinity;
+
+        foreach (var part in vessel.protoVessel.protoPartSnapshots)
+        {
+            var flightId = part.flightID;
+
+            foreach (var resource in part.resources)
+            {
+                var inventory = new ResourceInventory(
+                    resource.resourceName,
+                    resource.amount,
+                    resource.maxAmount
+                )
+                {
+                    FlightId = flightId,
+                    OriginalAmount = resource.amount,
+                    Snapshot = resource,
+                };
+
+                var id = inventory.Id;
+                if (inventoryIds.ContainsKey(id))
+                    continue;
+
+                inventoryIds.Add(id, inventories.Count);
+                inventories.Add(inventory);
+            }
+        }
+
+        snapshotsDirty = false;
+    }
     #endregion
 
     /// <summary>


### PR DESCRIPTION
External integrations expecting to use BRPs inventory will find nothing if the ship hasn't been loaded once by BRP. This causes problems when those integrations are expecting there to be resources.